### PR TITLE
Misc Changes: 05/25/2025

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -32,10 +32,6 @@ sourceSets {
 repositories {
     mavenCentral()
     mavenLocal()
-    maven { url = uri("https://raw.githubusercontent.com/redhat-developer/quarkus-ls/maven/") }
-    maven { url = uri("https://repository.jboss.org/nexus/content/groups/public") }
-    maven { url = uri("https://repo.eclipse.org/content/repositories/lsp4mp-snapshots") }
-    maven { url = uri("https://repo.eclipse.org/content/repositories/lsp4mp-releases") }
     // IntelliJ Platform Gradle Plugin Repositories Extension - read more: https://plugins.jetbrains.com/docs/intellij/tools-intellij-platform-gradle-plugin-repositories-extension.html
     intellijPlatform {
         defaultRepositories()
@@ -47,10 +43,6 @@ dependencies {
     testImplementation(libs.junit)
     testImplementation(libs.opentest4j)
     compileOnly("org.jetbrains:grammar-kit:2023.3")
-
-    implementation("com.redhat.microprofile:com.redhat.qute.ls:0.17.0") {
-        exclude("org.eclipse.lsp4j")
-    }
     // IntelliJ Platform Gradle Plugin Dependencies Extension - read more: https://plugins.jetbrains.com/docs/intellij/tools-intellij-platform-gradle-plugin-dependencies-extension.html
     intellijPlatform {
         create(providers.gradleProperty("platformType"), providers.gradleProperty("platformVersion"))
@@ -62,6 +54,8 @@ dependencies {
         plugins(providers.gradleProperty("platformPlugins").map { it.split(',') })
 
         testFramework(TestFrameworkType.Platform)
+
+        pluginVerifier(version="1.384")
     }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,12 +7,12 @@ pluginRepositoryUrl = https://github.com/Tbusk/vala-jetbrains-plugin
 pluginVersion = 1.0.0-ALPHA
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
-pluginSinceBuild = 242
+pluginSinceBuild = 251
 pluginUntilBuild = 252.*
 
 # IntelliJ Platform Properties -> https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html#configuration-intellij-extension
 platformType = IC
-platformVersion = 2024.2.5
+platformVersion = 2025.1.1.1
 
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html
 # Example: platformPlugins = com.jetbrains.php:203.4449.22, org.intellij.scala:2023.3.27@EAP


### PR DESCRIPTION
## Changes
- Removed unnecessary repositories and dependencies in `build.gradle.kts`
- Downgraded Intellij Plugin Verifier Gradle task to version 1.384 from 1.386 in `build.gradle.kts` due to it failing to resolve marketplace dependencies. This is a common issue right now, and is a working fix.
- Bumping Intellij Community Edition versioning to latest public release in `gradle.properties`.