### PR TITLE
[FEATURE]: Add more OS support for LSP 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,10 @@
 <!-- Keep a Changelog guide -> https://keepachangelog.com -->
 
 # vala-jetbrains-plugin Changelog
-## Version 1.0.1-ALPHA
+## [1.0.1-ALPHA]
 ### Added
 - Support for MacOS and Windows platforms with the LSP server.
 
-## Version 1.0.0-ALPHA
+## [1.0.0-ALPHA]
 ### Added
 - Initial version with basic features: lsp support, syntax highlighting, file creation.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,14 @@
 <!-- Keep a Changelog guide -> https://keepachangelog.com -->
 
 # vala-jetbrains-plugin Changelog
+## [Unreleased]
+### Added
+- tbd
+
 ## [1.0.1-ALPHA]
 ### Added
 - Support for MacOS and Windows platforms with the LSP server.
 
-## [1.0.0-ALPHA]
+## 1.0.0-ALPHA
 ### Added
 - Initial version with basic features: lsp support, syntax highlighting, file creation.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
 <!-- Keep a Changelog guide -> https://keepachangelog.com -->
 
 # vala-jetbrains-plugin Changelog
+## Version 1.0.1-ALPHA
+### Added
+- Support for MacOS and Windows platforms with the LSP server.
 
-## [Unreleased]
+## Version 1.0.0-ALPHA
 ### Added
 - Initial version with basic features: lsp support, syntax highlighting, file creation.

--- a/src/main/java/com/tbusk/vala_plugin/lsp/ValaLanguageServer.java
+++ b/src/main/java/com/tbusk/vala_plugin/lsp/ValaLanguageServer.java
@@ -3,11 +3,42 @@ package com.tbusk.vala_plugin.lsp;
 import com.intellij.execution.configurations.GeneralCommandLine;
 import com.redhat.devtools.lsp4ij.server.OSProcessStreamConnectionProvider;
 
+/**
+ * ValaLanguageServer is a class that extends OSProcessStreamConnectionProvider.
+ * <br/>
+ * It provides the command line configuration for the Vala Language Server based on the operating system.
+ * <br/>
+ * The command line is set in the constructor and can be used to start the language server process.
+ */
 public class ValaLanguageServer extends OSProcessStreamConnectionProvider {
 
-    public ValaLanguageServer() {
-        GeneralCommandLine commandLine = new GeneralCommandLine("/usr/bin/vala-language-server", "vala-language-server");
+    // Default command paths for different operating systems
+    private static final String DEFAULT_WINDOWS_COMMAND_PATH = "vala-language-server";
+    private static final String DEFAULT_MAC_COMMAND_PATH = "/usr/local/bin/vala-language-server";
+    private static final String DEFAULT_LINUX_COMMAND_PATH = "/usr/bin/vala-language-server";
 
-        super.setCommandLine(commandLine);
+    public ValaLanguageServer() {
+        super.setCommandLine(getCommandLineOSConfiguration());
+    }
+
+    /**
+     * Returns a command line based on the operating system.
+     * This method checks the OS name and returns the appropriate command line for the Vala Language Server.
+     *
+     * @return GeneralCommandLine configured for the current OS
+     */
+    public GeneralCommandLine getCommandLineOSConfiguration() {
+        String osName = System.getProperty("os.name").toLowerCase();
+
+        if(osName.contains("windows")) {
+            return new GeneralCommandLine(DEFAULT_WINDOWS_COMMAND_PATH);
+        } else if (osName.contains("mac")) {
+            return new GeneralCommandLine(DEFAULT_MAC_COMMAND_PATH);
+        } else if (osName.contains("linux")) {
+            return new GeneralCommandLine(DEFAULT_LINUX_COMMAND_PATH);
+        }
+
+        throw new UnsupportedOperationException("Unsupported operating system: " + System.getProperty("os.name"));
+
     }
 }

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -2,7 +2,6 @@
 <idea-plugin>
     <id>com.tbusk.vala_plugin</id>
     <name>Vala</name>
-    <version>0.01</version>
     <vendor email="trevor@tbusk.com" url="https://github.com/Tbusk/vala-jetbrains-plugin">tbusk</vendor>
 
     <depends>com.intellij.modules.platform </depends>


### PR DESCRIPTION
## Description
- Removing versioning from `plugin.xml` as versioning comes from `CHANGELOG.md` and releases.
- Adding change to `CHANGELOG.md`
- Adding support for Mac and Windows OS default LSP configuration.

A limitation with Windows is the path to the `vala-language-server` executable needs to be added to PATH in System Environment Variables.