### PR TITLE
[FEATURE]: LSP Configuration via Settings, LSP Docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,22 +13,16 @@ This plugin provides syntax highlighting, code completion, and other features fo
 This currently is in an early stage of development. Most luxuries of JetBrain IDEs are not implemented yet or are limited.
 
 A Language Server Protocol (LSP) is used to provide many features, including documentation, code completion, syntax checking, etc.
-The supported LSP is required to be installed separately, and is found [here](https://github.com/vala-lang/vala-language-server).
 
-Currently, the project expects the download location to be in `/usr/bin/vala-language-server` and is ran with `vala-language-server`. 
-The path and command to run can be configured in `src/main/java/com/tbusk/vala_plugin/lsp/ValaLanguageServer.java`. 
-Support for in-settings configuration is planned.
-
-Largely, the LSP can be installed in a command or two.  It likely is already installed if you are using other IDEs like VSCode or Neovim with the Vala plugin.
+The supported LSP is required to be installed separately for now. More details for the LSP are available [here](https://github.com/Tbusk/vala-jetbrains-plugin/blob/main/docs/LanguageServer.md).
 
 If you want to support this project or encounter any problems, please consider opening issues (features requests, bug fixes, etc.) or pull requests on our GitHub repository [here](https://github.com/Tbusk/vala-jetbrains-plugin).
 
 <!-- Plugin description end -->
 
 ## Project Development Phases
-
-1. Improve syntax highlighting and enhance compatability with themes and color customization with the language.
-2. Add support for LSP to be at default download positions based on OS, and then further customized in settings.
+1. Add support for LSP to be at default download positions based on OS, and then further customized in settings.
+2. Improve syntax highlighting and enhance compatability with themes and color customization with the language.
 3. Add additional feature support, including most refactor methods to improve development experience.
 4. Add runnability support to make files executable.
 5. Add installation capabilities if the LSP is not found so it can be installed and downloaded.

--- a/docs/LanguageServer.md
+++ b/docs/LanguageServer.md
@@ -1,0 +1,77 @@
+## Language Server Configuration
+
+The current supported language server is `vala-language-server`, which is an official language server for Vala available 
+at https://github.com/vala-lang/vala-language-server. 
+
+It provides features like code completion, syntax checking, and more, enhancing the development experience.  It is used
+with other Vala IDE plugins like Zed, VSCode, and NeoVim.
+
+Other language servers like https://gitlab.gnome.org/esodan/gvls can be supported provided you specify the path to the 
+executable in the plugin settings.  That LSP has not been tested, so it may not work as expected.
+
+To configure the path of the LSP or command used, 
+<kbd>⚙️</kbd> > <kbd>Settings</kbd> > <kbd>Tools</kbd> > <kbd>Vala Plugin Settings</kbd> > 
+`Specify path` > <kbd>Apply</kbd>
+
+### Language Server Manager
+The plugin uses the RedHat LSP4IJ manager to handle the language server, which is available at 
+https://github.com/redhat-developer/lsp4ij and https://plugins.jetbrains.com/plugin/23257-lsp4ij. This allows for easy 
+management of the language server. While not supported by JetBrains, it is a community plugin that is actively 
+maintained and provides a good experience for Vala development.
+
+The JetBrains supported LSP configuration is restricted to paid versions of the IDE, so it is not used.
+
+The docs for LSP4IJ can be found at https://github.com/redhat-developer/lsp4ij/tree/main/docs.
+
+### Installation
+
+To get the most up-to-date instructions, go to https://github.com/vala-lang/vala-language-server.
+
+Automated installation is possible with RedHat LSP4IJ, the LSP manager for the plugin, but will be worked on at a later date.
+
+#### Installation Commands
+_Arch Linux (via AUR)_: `yay -S vala-language-server` or `yay -S vala-language-server-git`
+
+_Ubuntu, Fedora, Debian, openSUSE, and Mageia_: install from the OBS repo build result
+
+_Fedora (official)_: `sudo dnf install vala-language-server`
+
+_elementaryOS_: `sudo apt install vala-language-server`
+
+_Alpine Linux_: `apk add vala-language-server`
+
+_Guix_: `guix install vala-language-server`
+
+_Void Linux_: `xbps-install vala-language-server`
+
+_Windows (via MSYS2)_: `pacman -S mingw-w64-x86_64-vala-language-server`
+
+
+### Windows
+The easiest way to configure the language server on Windows is to locate the path to the `vala-language-server` executable
+and set the `PATH` environment variable in your settings.
+If you do this, then you can use `language-server-protocol` instead of having to specify the path to it.
+
+**Note**: developing with Windows does require you to manually install each dependency used in a project, which needs to be
+satisfied for the language server to work properly.
+
+### Linux
+The default path for the language server is `/usr/bin/vala-language-server`.
+
+You also should be able to get away with using `language-server-protocol` as the path instead assuming you can run it 
+in your terminal with that command.
+
+### macOS
+The default path for the language server is `/usr/local/bin/vala-language-server`.
+
+You also should be able to get away with using `language-server-protocol` as the path instead assuming you can run it
+in your terminal with that command.  
+
+## Development
+All LSP functionality is implemented in the `lsp` package, which is set up for `lsp4ij` from RedHat.
+
+There is also an additional configuration area in `plugin.xml` for managing the plugin and language server settings.
+
+There also is an area in `settings` package which is used for managing the lsp path settings.  
+
+A developer guide for `lsp4ij` can be found at https://github.com/redhat-developer/lsp4ij/blob/main/docs/DeveloperGuide.md.

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ pluginGroup = com.tbusk.vala_plugin
 pluginName = Vala Language
 pluginRepositoryUrl = https://github.com/Tbusk/vala-jetbrains-plugin
 # SemVer format -> https://semver.org
-pluginVersion = 1.0.0-ALPHA
+pluginVersion = 1.1.0-ALPHA
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 pluginSinceBuild = 251

--- a/src/main/java/com/tbusk/vala_plugin/lsp/DefaultLanguageServerPathProvider.java
+++ b/src/main/java/com/tbusk/vala_plugin/lsp/DefaultLanguageServerPathProvider.java
@@ -1,0 +1,60 @@
+package com.tbusk.vala_plugin.lsp;
+
+/**
+ * DefaultLanguageServerPathProvider is a singleton class that provides the command line configuration
+ * for the Vala Language Server based on the operating system.
+ * <br/>
+ * It determines the appropriate command path for the language server depending on whether
+ * the application is running on Windows, macOS, or Linux.
+ */
+public final class DefaultLanguageServerPathProvider {
+
+    private static DefaultLanguageServerPathProvider INSTANCE;
+
+    // Default command paths for different operating systems
+    private static final String DEFAULT_WINDOWS_COMMAND_PATH = "vala-language-server";
+    private static final String DEFAULT_MAC_COMMAND_PATH = "/usr/local/bin/vala-language-server";
+    private static final String DEFAULT_LINUX_COMMAND_PATH = "/usr/bin/vala-language-server";
+
+    /**
+     * Private constructor to prevent instantiation.
+     * Use getInstance() to obtain the singleton instance.
+     */
+    private DefaultLanguageServerPathProvider() {
+    }
+
+    /**
+     * Returns the singleton instance of DefaultLanguageServerPathProvider.
+     *
+     * @return The singleton instance of DefaultLanguageServerPathProvider.
+     */
+    public static DefaultLanguageServerPathProvider getInstance() {
+        if (INSTANCE == null) {
+            INSTANCE = new DefaultLanguageServerPathProvider();
+        }
+
+        return INSTANCE;
+    }
+
+
+    /**
+     * Returns the command line configuration for the Vala Language Server based on the operating system.
+     *
+     * @return The command line path for the Vala Language Server.
+     * @throws UnsupportedOperationException if the operating system is not supported.
+     */
+    public String getCommandLineOSConfiguration() {
+        String osNameLowercase = System.getProperty("os.name").toLowerCase();
+
+        if(osNameLowercase.contains("windows")) {
+            return DEFAULT_WINDOWS_COMMAND_PATH;
+        } else if (osNameLowercase.contains("mac")) {
+            return DEFAULT_MAC_COMMAND_PATH;
+        } else if (osNameLowercase.contains("linux")) {
+            return DEFAULT_LINUX_COMMAND_PATH;
+        }
+
+        throw new UnsupportedOperationException("Unsupported operating system: " + System.getProperty("os.name"));
+
+    }
+}

--- a/src/main/java/com/tbusk/vala_plugin/lsp/ValaLanguageServerFactory.java
+++ b/src/main/java/com/tbusk/vala_plugin/lsp/ValaLanguageServerFactory.java
@@ -7,19 +7,43 @@ import com.redhat.devtools.lsp4ij.server.StreamConnectionProvider;
 import org.eclipse.lsp4j.services.LanguageServer;
 import org.jetbrains.annotations.NotNull;
 
+/**
+ * Factory for creating the Vala Language Server.
+ * <br/>
+ * This class implements the LanguageServerFactory interface to provide
+ * the necessary server-related functionality.
+ */
 public class ValaLanguageServerFactory implements LanguageServerFactory {
 
-
+    /**
+     * Creates a connection provider for the Vala Language Server.
+     *
+     * @param project - the current project
+     * @return a StreamConnectionProvider for the Vala Language Server
+     */
     @Override
     public @NotNull StreamConnectionProvider createConnectionProvider(@NotNull Project project) {
-        return new ValaLanguageServer();
+        return ValaLanguageServer.getInstance();
     }
 
+    /**
+     * Creates a language client for the Vala Language Server.
+     * This is useful for providing client specific features.
+     *
+     * @param project - the current project
+     * @return LanguageClientImpl - for the Vala Language Server
+     */
     @Override
     public @NotNull LanguageClientImpl createLanguageClient(@NotNull Project project) {
         return LanguageServerFactory.super.createLanguageClient(project);
     }
 
+    /**
+     * Returns the interface class for the Vala Language Server.
+     * This method is used to expose custom server API.
+     *
+     * @return Class<? extends LanguageServer> - the Vala Language Server API interface
+     */
     @Override
     public @NotNull Class<? extends LanguageServer> getServerInterface() {
         return ValaLanguageServerAPI.class;

--- a/src/main/java/com/tbusk/vala_plugin/settings/PluginSettings.java
+++ b/src/main/java/com/tbusk/vala_plugin/settings/PluginSettings.java
@@ -1,0 +1,64 @@
+package com.tbusk.vala_plugin.settings;
+
+import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.components.PersistentStateComponent;
+import com.intellij.openapi.components.State;
+import com.intellij.openapi.components.Storage;
+import com.tbusk.vala_plugin.lsp.LanguageServerPathProvider;
+import org.jetbrains.annotations.NonNls;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * This class holds the settings for the Vala plugin.
+ * It is used to store and retrieve persistent data for the plugin.
+ * Currently only the path to the Vala Language Server is stored.
+ * <br/>
+ * https://plugins.jetbrains.com/docs/intellij/settings-tutorial.html#the-appsettings-class
+ */
+@State(
+        name = "com.tbusk.vala_plugin.settings.PluginSettings",
+        storages = @Storage("ValaPluginSettings.xml")
+)
+public final class PluginSettings implements PersistentStateComponent<PluginSettings.State> {
+
+    /**
+     * This class holds the state of the plugin settings.
+     * It contains the path to the Vala Language Server.
+     */
+    public static class State {
+        private LanguageServerPathProvider languageServerPathProvider = LanguageServerPathProvider.getInstance();
+        @NonNls
+        public String lspServerPath = languageServerPathProvider.getCommandLineOSConfiguration();
+    }
+
+    private State pluginState = new State();
+
+    /**
+     * Retrieves the singleton instance of PluginSettings.
+     *
+     * @return the instance of PluginSettings
+     */
+    public static PluginSettings getInstance() {
+        return ApplicationManager.getApplication().getService(PluginSettings.class);
+    }
+
+    /**
+     * Returns the current state of the plugin settings.
+     *
+     * @return the current state of the plugin settings, or null if not set
+     */
+    @Override
+    public @Nullable PluginSettings.State getState() {
+        return pluginState;
+    }
+
+    /**
+     * Loads the state of the plugin settings from the provided state.
+     * @param state the state to load
+     */
+    @Override
+    public void loadState(@NotNull State state) {
+        pluginState = state;
+    }
+}

--- a/src/main/java/com/tbusk/vala_plugin/settings/PluginSettings.java
+++ b/src/main/java/com/tbusk/vala_plugin/settings/PluginSettings.java
@@ -4,7 +4,7 @@ import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.components.PersistentStateComponent;
 import com.intellij.openapi.components.State;
 import com.intellij.openapi.components.Storage;
-import com.tbusk.vala_plugin.lsp.LanguageServerPathProvider;
+import com.tbusk.vala_plugin.lsp.DefaultLanguageServerPathProvider;
 import org.jetbrains.annotations.NonNls;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -14,7 +14,7 @@ import org.jetbrains.annotations.Nullable;
  * It is used to store and retrieve persistent data for the plugin.
  * Currently only the path to the Vala Language Server is stored.
  * <br/>
- * https://plugins.jetbrains.com/docs/intellij/settings-tutorial.html#the-appsettings-class
+ * <a href="https://plugins.jetbrains.com/docs/intellij/settings-tutorial.html#the-appsettings-class">view plugin docs...</a>
  */
 @State(
         name = "com.tbusk.vala_plugin.settings.PluginSettings",
@@ -27,9 +27,9 @@ public final class PluginSettings implements PersistentStateComponent<PluginSett
      * It contains the path to the Vala Language Server.
      */
     public static class State {
-        private LanguageServerPathProvider languageServerPathProvider = LanguageServerPathProvider.getInstance();
+        private DefaultLanguageServerPathProvider defaultLanguageServerPathProvider = DefaultLanguageServerPathProvider.getInstance();
         @NonNls
-        public String lspServerPath = languageServerPathProvider.getCommandLineOSConfiguration();
+        public String lspServerPath = defaultLanguageServerPathProvider.getCommandLineOSConfiguration();
     }
 
     private State pluginState = new State();

--- a/src/main/java/com/tbusk/vala_plugin/settings/PluginSettingsComponent.java
+++ b/src/main/java/com/tbusk/vala_plugin/settings/PluginSettingsComponent.java
@@ -1,0 +1,114 @@
+package com.tbusk.vala_plugin.settings;
+
+import com.intellij.openapi.fileChooser.FileChooserDescriptorFactory;
+import com.intellij.openapi.project.ProjectManager;
+import com.intellij.openapi.ui.TextFieldWithBrowseButton;
+import com.intellij.ui.TitledSeparator;
+import com.intellij.ui.components.JBLabel;
+import com.intellij.util.ui.FormBuilder;
+import org.jetbrains.annotations.NotNull;
+
+import javax.swing.*;
+
+/**
+ * PluginSettingsComponent is a class that provides the UI component for the plugin settings.
+ * <br/>
+ * It contains a text field for the language server path and a label.
+ * <br/>
+ * The component can be used to get and set the language server path.
+ */
+public class PluginSettingsComponent {
+
+    private final JPanel mainPanel;
+    private final TextFieldWithBrowseButton languageServerPathTextField;
+    JBLabel languageServerPathLabel = new JBLabel("Language Server Path:");
+
+
+    /**
+     * Constructor for PluginSettingsComponent.
+     * <br/>
+     * Initializes the text field for the language server path and sets up the main panel.
+     */
+    public PluginSettingsComponent() {
+        languageServerPathTextField = setupLanguageServerPathTextField();
+        mainPanel = setupMainPanel();
+    }
+
+    /**
+     * Sets up the main panel for the settings component.
+     * <br/>
+     * The panel contains a titled separator and a labeled component for the language server path.
+     *
+     * @return a JPanel containing the settings UI components
+     */
+    public JPanel setupMainPanel() {
+        return FormBuilder.createFormBuilder()
+                .addComponent(new TitledSeparator("LSP Settings"), 1)
+                .addLabeledComponent(languageServerPathLabel, languageServerPathTextField, 1, false)
+                .addComponentFillVertically(new JPanel(), 0)
+                .getPanel();
+    }
+
+    /**
+     * Sets up the text field for the language server path with a browse button.
+     * <br/>
+     * The text field is initialized with the current language server path from the plugin settings.
+     * <br/>
+     * A file chooser is added to allow users to select the language server executable.
+     *
+     * @return a TextFieldWithBrowseButton for selecting the language server path
+     */
+    public TextFieldWithBrowseButton setupLanguageServerPathTextField() {
+        TextFieldWithBrowseButton textField = new TextFieldWithBrowseButton();
+
+        textField.setText(PluginSettings.getInstance().getState().lspServerPath);
+
+        textField.addBrowseFolderListener(
+                ProjectManager.getInstance().getDefaultProject(),
+                FileChooserDescriptorFactory.singleFile().withFileFilter(
+                        file -> file.exists() &&
+                                file.getNameWithoutExtension().equals("vala-language-server")
+                )
+        );
+
+        return textField;
+    }
+
+    /**
+     * Gets the main panel of the settings component.
+     *
+     * @return the main panel
+     */
+    public JPanel getMainPanel() {
+        return mainPanel;
+    }
+
+    /**
+     * Gets the preferred focused component for the settings dialog.
+     *
+     * @return the text field for the language server path
+     */
+    public JComponent getPreferredFocusedComponent() {
+        return languageServerPathTextField;
+    }
+
+    /**
+     * Gets the language server path from the text field.
+     *
+     * @return the language server path
+     */
+    @NotNull
+    public String getLanguageServerPath() {
+
+        return languageServerPathTextField.getText();
+    }
+
+    /**
+     * Sets the language server path in the text field.
+     *
+     * @param path the path to set
+     */
+    public void setLanguageServerPath(@NotNull String path) {
+        languageServerPathTextField.setText(path);
+    }
+}

--- a/src/main/java/com/tbusk/vala_plugin/settings/PluginSettingsConfigurable.java
+++ b/src/main/java/com/tbusk/vala_plugin/settings/PluginSettingsConfigurable.java
@@ -1,0 +1,111 @@
+package com.tbusk.vala_plugin.settings;
+
+import com.intellij.openapi.options.Configurable;
+import com.intellij.openapi.options.ConfigurationException;
+import com.intellij.openapi.util.NlsContexts;
+import com.tbusk.vala_plugin.lsp.ValaLanguageServer;
+import org.jetbrains.annotations.Nullable;
+
+import javax.swing.*;
+import java.util.Objects;
+
+/**
+ * PluginSettingsConfigurable is a class that implements the Configurable interface.
+ * <br/>
+ * It manages the state and UI of the plugin settings.
+ */
+public class PluginSettingsConfigurable implements Configurable {
+
+    private PluginSettingsComponent settingsComponent;
+
+    /**
+     * Returns the display name of the settings configurable shown when browsing the settings area.
+     * <br/>
+     * This method is used to provide a user-friendly name for the settings page.
+     *
+     * @return String - the display name of the settings configurable
+     */
+    @Override
+    public @NlsContexts.ConfigurableName String getDisplayName() {
+        return "Vala Plugin Settings";
+    }
+
+    /**
+     * Returns the preferred focused component of the settings component.
+     * <br/>
+     * This method is used to set the initial focus when the settings dialog is opened.
+     * @return JComponent - the preferred focused component
+     */
+    @Override
+    public JComponent getPreferredFocusedComponent() {
+        return settingsComponent.getPreferredFocusedComponent();
+    }
+
+    /**
+     * Creates the UI component for the settings.
+     * <br/>
+     * This method initializes the settings component and returns its main panel.
+     *
+     * @return JComponent - the main panel of the settings component
+     */
+    @Override
+    public @Nullable JComponent createComponent() {
+        settingsComponent = new PluginSettingsComponent();
+
+        return settingsComponent.getMainPanel();
+    }
+
+    /**
+     * Checks if the settings have been modified.
+     * <br/>
+     * This method compares the current settings with the saved state to determine if any changes have been made.
+     *
+     * @return boolean - true if the settings have been modified, false otherwise
+     */
+    @Override
+    public boolean isModified() {
+        PluginSettings.State state = Objects.requireNonNull(PluginSettings.getInstance().getState());
+
+        return !state.lspServerPath.equals(settingsComponent.getLanguageServerPath());
+    }
+
+    /**
+     * Applies the changes made in the settings component.
+     * <br/>
+     * This method updates the plugin settings with the new language server path and applies the changes to the Vala Language Server.
+     *
+     * @throws ConfigurationException if there is an error applying the configuration
+     */
+    @Override
+    public void apply() throws ConfigurationException {
+        PluginSettings.State state = Objects.requireNonNull(PluginSettings.getInstance().getState());
+
+        state.lspServerPath = settingsComponent.getLanguageServerPath();
+
+        ValaLanguageServer.getInstance().updateCommandLineConfiguration(
+                state.lspServerPath
+        );
+    }
+
+    /**
+     * Resets the settings component to the saved state.
+     * <br/>
+     * This method restores the language server path from the plugin settings state.
+     */
+    @Override
+    public void reset() {
+        PluginSettings.State state = Objects.requireNonNull(PluginSettings.getInstance().getState());
+
+        settingsComponent.setLanguageServerPath(state.lspServerPath);
+    }
+
+    /**
+     * Disposes of the UI resources used by the settings component.
+     * <br/>
+     * This method is called when the settings dialog is closed to clean up any resources used by the settings component.
+     */
+    @Override
+    public void disposeUIResources() {
+        settingsComponent = null;
+    }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -44,6 +44,15 @@
         <typedHandler implementation="com.tbusk.vala_plugin.editing.CharacterAutoCloser"/>
 
         <colorSettingsPage implementation="com.tbusk.vala_plugin.highlighting.ValaColorSettingsPage"/>
+
+        <applicationService
+            serviceImplementation="com.tbusk.vala_plugin.settings.PluginSettings" />
+
+        <applicationConfigurable
+            parentId="tools"
+            instance="com.tbusk.vala_plugin.settings.PluginSettingsConfigurable"
+            id="com.tbusk.vala_plugin.settings.PluginSettingsConfigurable"
+            displayName="Vala Plugin Settings" />
     </extensions>
 
     <actions >


### PR DESCRIPTION
Closes #13 

## Description
- Added settings page with option to change LSP path either with text path or file selection.
- Configuration change requests restart for the user to ensure that the language server reloads properly with the new configuration.
- Added Language Server documentation in `docs/LanguageServer.md`

### Links
- https://github.com/redhat-developer/lsp4ij/blob/main/docs/DeveloperGuide.md
- https://plugins.jetbrains.com/docs/intellij/settings-tutorial.html#creating-the-appsettings-implementation
- https://intellij-support.jetbrains.com/hc/en-us/community/posts/206105709-How-do-you-make-a-plugin-setting-change-require-a-restart