### PR TITLE
[CHANGE]: Change LSP4IJ and language configuration in plugin.xml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 # vala-jetbrains-plugin Changelog
 ## [Unreleased]
 ### What's Changed
+- Adding semantic token colorization support from the language server.
+
+## [1.1.1-ALPHA]
+### What's Changed
 - Added additional keywords for syntax highlighting and to parser/lexer.
 - Added additional configurability for color customization.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 ## [Unreleased]
 ### What's Changed
 - Adding semantic token colorization support from the language server.
+- Adding Lsp4ij configuration for code insight, spell checker, folding builder, psi structure viewer, and parameter
+  info.
+- Adding syntax highlighting for .in files.
 
 ## [1.1.1-ALPHA]
 ### What's Changed

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ pluginGroup = com.tbusk.vala_plugin
 pluginName = Vala Language
 pluginRepositoryUrl = https://github.com/Tbusk/vala-jetbrains-plugin
 # SemVer format -> https://semver.org
-pluginVersion = 1.1.1-ALPHA
+pluginVersion = 1.1.2-ALPHA
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 pluginSinceBuild = 251

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -2,25 +2,36 @@
 <idea-plugin>
     <id>com.tbusk.vala_plugin</id>
     <name>Vala</name>
-    <vendor email="trevor@tbusk.com" url="https://github.com/Tbusk/vala-jetbrains-plugin">tbusk</vendor>
+    <vendor email="trevor@tbusk.com"
+            url="https://github.com/Tbusk/vala-jetbrains-plugin">
+        tbusk
+    </vendor>
 
     <depends>com.intellij.modules.platform </depends>
     <depends>com.redhat.devtools.lsp4ij</depends>
 
     <extensions defaultExtensionNs="com.redhat.devtools.lsp4ij">
-        <server id="vala"
+        <server id="vala-server"
                 name="Vala Language Server"
                 factoryClass="com.tbusk.vala_plugin.lsp.ValaLanguageServerFactory">
-            <description><![CDATA[
-        Vala Language Server
-        ]]>
+            <description>
+                <![CDATA[Vala Language Server]]>
             </description>
         </server>
 
-        <languageMapping language="Vala" serverId="vala"/>
-        <fileTypeMapping fileType="vala" serverId="vala"/>
-        <fileNamePatternMapping patterns="*.vala;*.vapi" serverId="vala"/>
-        <semanticTokensColorsProvider serverId="vala"
+        <languageMapping language="Vala"
+                         serverId="vala-server"
+                         languageId="vala"/>
+
+        <fileTypeMapping fileType="vala;vapi;vala.in"
+                         serverId="vala-server"
+                         languageId="vala"/>
+
+        <fileNamePatternMapping patterns="*.vala;*.vapi;*.in"
+                                serverId="vala-server"
+                                languageId="vala"/>
+
+        <semanticTokensColorsProvider serverId="vala-server"
                                       class="com.redhat.devtools.lsp4ij.features.semanticTokens.DefaultSemanticTokensColorsProvider"/>
 
 
@@ -32,7 +43,7 @@
                 implementationClass="com.tbusk.vala_plugin.language.ValaFileType"
                 fieldName="INSTANCE"
                 language="Vala"
-                extensions="vala;vapi"/>
+                extensions="vala;vapi;in"/>
 
         <lang.parserDefinition
                 language="Vala"
@@ -42,7 +53,19 @@
                 language="Vala"
                 implementationClass="com.tbusk.vala_plugin.highlighting.ValaSyntaxHighlighterFactory"/>
 
-        <spellchecker.support language="Vala" implementationClass="com.tbusk.vala_plugin.spell_checker.ValaSpellCheckingStrategy"/>
+        <lang.foldingBuilder language="Vala"
+                             implementationClass="com.redhat.devtools.lsp4ij.features.foldingRange.LSPFoldingRangeBuilder"
+                             order="first"/>
+
+        <lang.psiStructureViewFactory language="Vala"
+                                      implementationClass="com.redhat.devtools.lsp4ij.features.documentSymbol.LSPDocumentSymbolStructureViewFactory"/>
+
+        <codeInsight.parameterInfo language="Vala"
+                                   implementationClass="com.redhat.devtools.lsp4ij.features.signatureHelp.LSPParameterInfoHandler"/>
+
+
+        <spellchecker.support language="Vala"
+                              implementationClass="com.tbusk.vala_plugin.spell_checker.ValaSpellCheckingStrategy"/>
 
         <typedHandler implementation="com.tbusk.vala_plugin.editing.CharacterAutoCloser"/>
 
@@ -59,8 +82,14 @@
     </extensions>
 
     <actions >
-        <action id="CreateValaFile" class="com.tbusk.vala_plugin.actions.ValaCreateFileAction" text="Create Vala File" description="Create a new Vala file">
-            <add-to-group group-id="NewGroup" anchor="before" relative-to-action="NewFile"/>
+        <action id="CreateValaFile"
+                class="com.tbusk.vala_plugin.actions.ValaCreateFileAction"
+                text="Create Vala File"
+                description="Create a new Vala file">
+
+            <add-to-group group-id="NewGroup"
+                          anchor="before"
+                          relative-to-action="NewFile"/>
         </action>
     </actions>
 </idea-plugin>

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -20,8 +20,6 @@
         <languageMapping language="Vala" serverId="vala"/>
         <fileTypeMapping fileType="vala" serverId="vala"/>
         <fileNamePatternMapping patterns="*.vala;*.vapi" serverId="vala"/>
-        <semanticTokensColorsProvider serverId="vala"
-                                        class="com.redhat.devtools.lsp4ij.features.semanticTokens.SemanticTokensColorsProvider"/>
 
     </extensions>
 

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -20,6 +20,9 @@
         <languageMapping language="Vala" serverId="vala"/>
         <fileTypeMapping fileType="vala" serverId="vala"/>
         <fileNamePatternMapping patterns="*.vala;*.vapi" serverId="vala"/>
+        <semanticTokensColorsProvider serverId="vala"
+                                      class="com.redhat.devtools.lsp4ij.features.semanticTokens.DefaultSemanticTokensColorsProvider"/>
+
 
     </extensions>
 

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -20,6 +20,8 @@
         <languageMapping language="Vala" serverId="vala"/>
         <fileTypeMapping fileType="vala" serverId="vala"/>
         <fileNamePatternMapping patterns="*.vala;*.vapi" serverId="vala"/>
+        <semanticTokensColorsProvider serverId="vala"
+                                        class="com.redhat.devtools.lsp4ij.features.semanticTokens.SemanticTokensColorsProvider"/>
 
     </extensions>
 


### PR DESCRIPTION
## Description
- Specifying language id as some language servers expect one to be sent
over.
- Adding vala.in syntax and language server support (although
vala-language-server doesn't support .in files now).
- Adding semantic token color support if language server supports it
(vala-language-server doesn't right now)
- Adding config to register folding builder, psi structure view, and
parameter info