### PR TITLE
chore: add directories to ignore to qodana.yml

### DIFF
--- a/qodana.yml
+++ b/qodana.yml
@@ -10,3 +10,12 @@ exclude:
   - name: All
     paths:
       - .qodana
+      - src/main/gen/
+      - docs/
+      - .idea/
+      - .gradle/
+      - .run/
+      - jflex/
+      - gradle/
+      - build/
+      - .intellijPlatform/


### PR DESCRIPTION
## Description
Qodana is inspecting in too many directories. This'll add all directories that aren't wanted to be inspected to the ignore list.