### PR TITLE
patch: non-constant field declarations not permitted outside classes

### DIFF
--- a/src/main/java/com/tbusk/vala_plugin/syntax/Vala.bnf
+++ b/src/main/java/com/tbusk/vala_plugin/syntax/Vala.bnf
@@ -109,7 +109,6 @@ namespace_member ::= [ attributes ]
                        enum_declaration |
                        errordomain_declaration |
                        method_declaration |
-                       field_declaration |
                        constant_declaration)
 
 attributes ::= attribute*


### PR DESCRIPTION
Currently declarations of non-constants aren't permitted outside of a class.

Line 199 is what the compiler returns when tried:
https://gitlab.gnome.org/GNOME/vala/-/blob/main/vala/valafield.vala?ref_type=heads

But, the grammar file provided suggests it can be as a namespace member:
https://docs.vala.dev/contributor-guide/compiler-guide/03-00-the-vala-compiler/03-02-parser.html

Until the compiler changes, this will be adjusted to match it.