### PR TITLE
patch: allowing constants to be declared in statements

### DIFF
--- a/src/main/gen/com/tbusk/vala_plugin/ValaParser.java
+++ b/src/main/gen/com/tbusk/vala_plugin/ValaParser.java
@@ -3450,7 +3450,6 @@ public class ValaParser implements PsiParser, LightPsiParser {
   //                        enum_declaration |
   //                        errordomain_declaration |
   //                        method_declaration |
-  //                        field_declaration |
   //                        constant_declaration)
   public static boolean namespace_member(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "namespace_member")) return false;
@@ -3476,7 +3475,6 @@ public class ValaParser implements PsiParser, LightPsiParser {
   //                        enum_declaration |
   //                        errordomain_declaration |
   //                        method_declaration |
-  //                        field_declaration |
   //                        constant_declaration
   private static boolean namespace_member_1(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "namespace_member_1")) return false;
@@ -3488,7 +3486,6 @@ public class ValaParser implements PsiParser, LightPsiParser {
     if (!r) r = enum_declaration(b, l + 1);
     if (!r) r = errordomain_declaration(b, l + 1);
     if (!r) r = method_declaration(b, l + 1);
-    if (!r) r = field_declaration(b, l + 1);
     if (!r) r = constant_declaration(b, l + 1);
     return r;
   }
@@ -4569,7 +4566,7 @@ public class ValaParser implements PsiParser, LightPsiParser {
   /* ********************************************************** */
   // block | SEMICOLON | if_statement | switch_statement | while_statement | do_statement | for_statement | foreach_statement |
   //               break_statement | continue_statement | return_statement | yield_statement | throw_statement |
-  //               try_statement | delete_statement | local_variable_declarations | expression_statement | lock_statement
+  //               try_statement | delete_statement | local_variable_declarations | expression_statement | lock_statement | constant_declaration
   public static boolean statement(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "statement")) return false;
     boolean r;
@@ -4592,6 +4589,7 @@ public class ValaParser implements PsiParser, LightPsiParser {
     if (!r) r = local_variable_declarations(b, l + 1);
     if (!r) r = expression_statement(b, l + 1);
     if (!r) r = lock_statement(b, l + 1);
+    if (!r) r = constant_declaration(b, l + 1);
     exit_section_(b, l, m, r, false, null);
     return r;
   }

--- a/src/main/gen/com/tbusk/vala_plugin/psi/ValaNamespaceMember.java
+++ b/src/main/gen/com/tbusk/vala_plugin/psi/ValaNamespaceMember.java
@@ -23,9 +23,6 @@ public interface ValaNamespaceMember extends PsiElement {
   ValaErrordomainDeclaration getErrordomainDeclaration();
 
   @Nullable
-  ValaFieldDeclaration getFieldDeclaration();
-
-  @Nullable
   ValaInterfaceDeclaration getInterfaceDeclaration();
 
   @Nullable

--- a/src/main/gen/com/tbusk/vala_plugin/psi/ValaStatement.java
+++ b/src/main/gen/com/tbusk/vala_plugin/psi/ValaStatement.java
@@ -14,6 +14,9 @@ public interface ValaStatement extends PsiElement {
   ValaBreakStatement getBreakStatement();
 
   @Nullable
+  ValaConstantDeclaration getConstantDeclaration();
+
+  @Nullable
   ValaContinueStatement getContinueStatement();
 
   @Nullable

--- a/src/main/gen/com/tbusk/vala_plugin/psi/impl/ValaNamespaceMemberImpl.java
+++ b/src/main/gen/com/tbusk/vala_plugin/psi/impl/ValaNamespaceMemberImpl.java
@@ -59,12 +59,6 @@ public class ValaNamespaceMemberImpl extends ASTWrapperPsiElement implements Val
 
   @Override
   @Nullable
-  public ValaFieldDeclaration getFieldDeclaration() {
-    return findChildByClass(ValaFieldDeclaration.class);
-  }
-
-  @Override
-  @Nullable
   public ValaInterfaceDeclaration getInterfaceDeclaration() {
     return findChildByClass(ValaInterfaceDeclaration.class);
   }

--- a/src/main/gen/com/tbusk/vala_plugin/psi/impl/ValaStatementImpl.java
+++ b/src/main/gen/com/tbusk/vala_plugin/psi/impl/ValaStatementImpl.java
@@ -41,6 +41,12 @@ public class ValaStatementImpl extends ASTWrapperPsiElement implements ValaState
 
   @Override
   @Nullable
+  public ValaConstantDeclaration getConstantDeclaration() {
+    return findChildByClass(ValaConstantDeclaration.class);
+  }
+
+  @Override
+  @Nullable
   public ValaContinueStatement getContinueStatement() {
     return findChildByClass(ValaContinueStatement.class);
   }

--- a/src/main/java/com/tbusk/vala_plugin/syntax/Vala.bnf
+++ b/src/main/java/com/tbusk/vala_plugin/syntax/Vala.bnf
@@ -392,7 +392,7 @@ block ::= LBRACE statement* RBRACE
 // parse_statements
 statement ::= block | SEMICOLON | if_statement | switch_statement | while_statement | do_statement | for_statement | foreach_statement |
               break_statement | continue_statement | return_statement | yield_statement | throw_statement |
-              try_statement | delete_statement | local_variable_declarations | expression_statement | lock_statement
+              try_statement | delete_statement | local_variable_declarations | expression_statement | lock_statement | constant_declaration
 
 if_statement ::= if LPAREN expression RPAREN embedded_statement [ else embedded_statement ]
 


### PR DESCRIPTION
Tested via compilation and in other ides, and constants are permitted to
 be declared in statements like inside a method declaration. Updating bnf and generated parser.

 https://docs.vala.dev/contributor-guide/compiler-guide/03-00-the-vala-compiler/03-02-parser.html grammar didn't mark this was possible.