### PR TITLE
docs: adding solution to uncrustify dependency language server error msg

### DIFF
--- a/docs/LanguageServer.md
+++ b/docs/LanguageServer.md
@@ -13,6 +13,12 @@ To configure the path of the LSP or command used,
 <kbd>⚙️</kbd> > <kbd>Settings</kbd> > <kbd>Tools</kbd> > <kbd>Vala Plugin Settings</kbd> > 
 `Specify path` > <kbd>Apply</kbd>
 
+> **Note**: If you encounter this message: `Formatting failed: Failed to execute child process ?uncrustify? 
+> (No such file or directory)`, then you'll need to install a dependency called
+`uncrustify` https://github.com/uncrustify/uncrustify/. The language server says
+> it is optional, but it is required for the code help formatter, which can be
+> installed via your package manager. In ElementaryOS, you can install it with `sudo apt install uncrustify`.
+
 ### Language Server Manager
 The plugin uses the RedHat LSP4IJ manager to handle the language server, which is available at 
 https://github.com/redhat-developer/lsp4ij and https://plugins.jetbrains.com/plugin/23257-lsp4ij. This allows for easy 


### PR DESCRIPTION
## Description
When adding a file to a project without `uncrustify` installed, you'll get an error from the language server saying that `Formatting failed:
 Failed to execute child process ?uncrustify? (No such file or directory
 )`
 
This can be patched by installing the dependency. Looking at the source code in the `vala-language-server`, it does not appear to be optional in the sense that errors won't popup if it isn't used.