### PR TITLE
feature: add new project wizards for all IDEs, one with and one without meson integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,35 @@
 <!-- Keep a Changelog guide -> https://keepachangelog.com -->
 
 # vala-jetbrains-plugin Changelog
+
 ## [Unreleased]
+
 ### What's Changed
 
+- Added new Vala project wizard to Java-based IDEs
+- Added new Vala project wizard with Meson to Java-based IDEs
+- Added new Vala project wizard to non-Java-based IDEs
+- Added new Vala project wizard with Meson to non-Java-based IDEs
+
+## [1.1.3-ALPHA]
+### What's Changed
 - Update parser to permit constants being declared in statements.
 - Update parser to no longer permit non-constant variables being declared in the namespace.
 - Update parser to allow delegate declaration in the namespace.
+
+## [1.1.2-ALPHA]
+
+### What's Changed
+
+- Adding semantic token colorization support from the language server.
+- Adding LSP4IJ configuration for code insight, spell checker, folding builder, psi structure viewer, and parameter
+  info.
+- Adding syntax highlighting for .in files.
+- Adding comment out and uncomment functionality.
+- Adding single, double quotation, and backtick escape functionality.
+- Updated plugin logo and added a different dark mode icon.
+- Updated source file icon to be more consistent with the JetBrains theme.
+- Implemented robust parser that can handle majority of Vala syntax.
 
 ## [1.1.1-ALPHA]
 ### What's Changed

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ pluginGroup = com.tbusk.vala_plugin
 pluginName = Vala Language
 pluginRepositoryUrl = https://github.com/Tbusk/vala-jetbrains-plugin
 # SemVer format -> https://semver.org
-pluginVersion=1.1.3-ALPHA
+pluginVersion=1.2.0-ALPHA
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 pluginSinceBuild = 251

--- a/src/main/java/com/tbusk/vala_plugin/project/ProjectNameValidator.java
+++ b/src/main/java/com/tbusk/vala_plugin/project/ProjectNameValidator.java
@@ -1,0 +1,24 @@
+package com.tbusk.vala_plugin.project;
+
+import org.jetbrains.annotations.NotNull;
+
+public final class ProjectNameValidator {
+
+    private static final String VALID_NAME_REGEX = "^[a-zA-Z0-9/~]+([_\\-/.]*[a-zA-Z0-9])+$";
+    private static ProjectNameValidator instance;
+
+    private ProjectNameValidator() {
+    }
+
+    public static ProjectNameValidator getInstance() {
+        if (instance == null) {
+            instance = new ProjectNameValidator();
+        }
+
+        return instance;
+    }
+
+    public boolean isValid(@NotNull String name) {
+        return name.matches(VALID_NAME_REGEX);
+    }
+}

--- a/src/main/java/com/tbusk/vala_plugin/project/ValaLanguageGeneratorNewMesonProjectWizard.java
+++ b/src/main/java/com/tbusk/vala_plugin/project/ValaLanguageGeneratorNewMesonProjectWizard.java
@@ -1,0 +1,26 @@
+package com.tbusk.vala_plugin.project;
+
+import com.intellij.ide.wizard.NewProjectWizardStep;
+import com.intellij.ide.wizard.language.LanguageGeneratorNewProjectWizard;
+import com.tbusk.vala_plugin.language.ValaIcons;
+import org.jetbrains.annotations.NotNull;
+
+import javax.swing.*;
+
+public class ValaLanguageGeneratorNewMesonProjectWizard implements LanguageGeneratorNewProjectWizard {
+    @Override
+    public @NotNull String getName() {
+        return "Vala [Meson]";
+    }
+
+    @Override
+    public @NotNull Icon getIcon() {
+        return ValaIcons.FILE;
+    }
+
+    @Override
+    public @NotNull NewProjectWizardStep createStep(@NotNull NewProjectWizardStep newProjectWizardStep) {
+
+        return new ValaNewMesonProjectStep(newProjectWizardStep);
+    }
+}

--- a/src/main/java/com/tbusk/vala_plugin/project/ValaLanguageGeneratorNewProjectWizard.java
+++ b/src/main/java/com/tbusk/vala_plugin/project/ValaLanguageGeneratorNewProjectWizard.java
@@ -1,0 +1,26 @@
+package com.tbusk.vala_plugin.project;
+
+import com.intellij.ide.wizard.NewProjectWizardStep;
+import com.intellij.ide.wizard.language.LanguageGeneratorNewProjectWizard;
+import com.tbusk.vala_plugin.language.ValaIcons;
+import org.jetbrains.annotations.NotNull;
+
+import javax.swing.*;
+
+public class ValaLanguageGeneratorNewProjectWizard implements LanguageGeneratorNewProjectWizard {
+    @Override
+    public @NotNull String getName() {
+        return "Vala";
+    }
+
+    @Override
+    public @NotNull Icon getIcon() {
+        return ValaIcons.FILE;
+    }
+
+    @Override
+    public @NotNull NewProjectWizardStep createStep(@NotNull NewProjectWizardStep newProjectWizardStep) {
+
+        return new ValaNewProjectStep(newProjectWizardStep);
+    }
+}

--- a/src/main/java/com/tbusk/vala_plugin/project/ValaModuleBuilder.java
+++ b/src/main/java/com/tbusk/vala_plugin/project/ValaModuleBuilder.java
@@ -1,0 +1,31 @@
+package com.tbusk.vala_plugin.project;
+
+import com.intellij.ide.util.projectWizard.ModuleBuilder;
+import com.intellij.openapi.module.ModuleType;
+import com.tbusk.vala_plugin.language.ValaIcons;
+import org.jetbrains.annotations.NonNls;
+
+import javax.swing.*;
+
+public class ValaModuleBuilder extends ModuleBuilder {
+
+    @Override
+    public ModuleType<?> getModuleType() {
+        return ValaModuleType.getInstance();
+    }
+
+    @Override
+    public @NonNls String getBuilderId() {
+        return "VALA_MODULE_BUILDER";
+    }
+
+    @Override
+    public Icon getNodeIcon() {
+        return ValaIcons.FILE;
+    }
+
+    @Override
+    public String getName() {
+        return "Vala";
+    }
+}

--- a/src/main/java/com/tbusk/vala_plugin/project/ValaModuleType.java
+++ b/src/main/java/com/tbusk/vala_plugin/project/ValaModuleType.java
@@ -1,0 +1,46 @@
+package com.tbusk.vala_plugin.project;
+
+import com.intellij.openapi.module.ModuleType;
+import com.tbusk.vala_plugin.language.ValaIcons;
+import org.jetbrains.annotations.Nls;
+import org.jetbrains.annotations.NotNull;
+
+import javax.swing.*;
+
+public final class ValaModuleType extends ModuleType<ValaModuleBuilder> {
+
+    public static final String VALA_MODULE = "VALA_MODULE";
+    private static ValaModuleType instance;
+
+    private ValaModuleType() {
+        super(VALA_MODULE);
+    }
+
+    public static ValaModuleType getInstance() {
+        if (instance == null) {
+            instance = new ValaModuleType();
+        }
+
+        return instance;
+    }
+
+    @Override
+    public @NotNull ValaModuleBuilder createModuleBuilder() {
+        return new ValaModuleBuilder();
+    }
+
+    @Override
+    public @NotNull @Nls(capitalization = Nls.Capitalization.Title) String getName() {
+        return "Vala Module";
+    }
+
+    @Override
+    public @NotNull @Nls(capitalization = Nls.Capitalization.Sentence) String getDescription() {
+        return "Vala module";
+    }
+
+    @Override
+    public @NotNull Icon getNodeIcon(boolean isOpened) {
+        return ValaIcons.FILE;
+    }
+}

--- a/src/main/java/com/tbusk/vala_plugin/project/ValaNewMesonProjectStep.java
+++ b/src/main/java/com/tbusk/vala_plugin/project/ValaNewMesonProjectStep.java
@@ -1,0 +1,52 @@
+package com.tbusk.vala_plugin.project;
+
+import com.intellij.ide.wizard.AbstractNewProjectWizardStep;
+import com.intellij.ide.wizard.NewProjectWizardStep;
+import com.intellij.openapi.application.WriteAction;
+import com.intellij.openapi.module.Module;
+import com.intellij.openapi.module.ModuleManager;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.openapi.vfs.VirtualFileManager;
+import org.jetbrains.annotations.NotNull;
+
+import java.nio.file.Path;
+
+public class ValaNewMesonProjectStep extends AbstractNewProjectWizardStep {
+
+    public ValaNewMesonProjectStep(@NotNull NewProjectWizardStep parentStep) {
+        super(parentStep);
+    }
+
+    @Override
+    public void setupProject(@NotNull Project project) {
+        super.setupProject(project);
+
+        ModuleManager moduleManager = ModuleManager.getInstance(project);
+
+        VirtualFile workspaceFile = project.getWorkspaceFile();
+        if (workspaceFile == null) return;
+
+        String basePath = project.getBasePath();
+        if (basePath == null) return;
+
+        VirtualFile baseFile = VirtualFileManager.getInstance().findFileByNioPath(Path.of(basePath));
+        if (baseFile == null) return;
+
+        Path path = Path.of(workspaceFile.getParent().getPath(), project.getName());
+
+        try {
+            WriteAction.run(() -> {
+                try {
+                    Module module = moduleManager.newModule(path, ValaModuleType.VALA_MODULE);
+                    ValaProjectCreationUtil creationUtil = ValaProjectCreationUtil.getInstance();
+                    creationUtil.setupNewMesonProject(baseFile, project, module);
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                }
+            });
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/main/java/com/tbusk/vala_plugin/project/ValaNewProjectStep.java
+++ b/src/main/java/com/tbusk/vala_plugin/project/ValaNewProjectStep.java
@@ -1,0 +1,52 @@
+package com.tbusk.vala_plugin.project;
+
+import com.intellij.ide.wizard.AbstractNewProjectWizardStep;
+import com.intellij.ide.wizard.NewProjectWizardStep;
+import com.intellij.openapi.application.WriteAction;
+import com.intellij.openapi.module.Module;
+import com.intellij.openapi.module.ModuleManager;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.openapi.vfs.VirtualFileManager;
+import org.jetbrains.annotations.NotNull;
+
+import java.nio.file.Path;
+
+public class ValaNewProjectStep extends AbstractNewProjectWizardStep {
+
+    public ValaNewProjectStep(@NotNull NewProjectWizardStep parentStep) {
+        super(parentStep);
+    }
+
+    @Override
+    public void setupProject(@NotNull Project project) {
+        super.setupProject(project);
+
+        ModuleManager moduleManager = ModuleManager.getInstance(project);
+
+        VirtualFile workspaceFile = project.getWorkspaceFile();
+        if (workspaceFile == null) return;
+
+        String basePath = project.getBasePath();
+        if (basePath == null) return;
+
+        VirtualFile baseFile = VirtualFileManager.getInstance().findFileByNioPath(Path.of(basePath));
+        if (baseFile == null) return;
+
+        Path path = Path.of(workspaceFile.getParent().getPath(), project.getName());
+
+        try {
+            WriteAction.run(() -> {
+                try {
+                    Module module = moduleManager.newModule(path, ValaModuleType.VALA_MODULE);
+                    ValaProjectCreationUtil creationUtil = ValaProjectCreationUtil.getInstance();
+                    creationUtil.setupNewProject(baseFile, project, module);
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                }
+            });
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/main/java/com/tbusk/vala_plugin/project/ValaNonJavaEmptyProjectWizard.java
+++ b/src/main/java/com/tbusk/vala_plugin/project/ValaNonJavaEmptyProjectWizard.java
@@ -1,6 +1,7 @@
 package com.tbusk.vala_plugin.project;
 
 import com.intellij.facet.ui.ValidationResult;
+import com.intellij.openapi.command.WriteCommandAction;
 import com.intellij.openapi.module.Module;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.NlsContexts;
@@ -9,10 +10,14 @@ import com.intellij.platform.DirectoryProjectGenerator;
 import com.tbusk.vala_plugin.language.ValaIcons;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.swing.*;
 
-public class ValaNonJavaEmptyProjectWizard implements DirectoryProjectGenerator {
+public class ValaNonJavaEmptyProjectWizard implements DirectoryProjectGenerator<Object> {
+    private static final Logger log = LoggerFactory.getLogger(ValaNonJavaEmptyProjectWizard.class);
+
     @Override
     public @NotNull @NlsContexts.Label String getName() {
         return "Vala project";
@@ -24,12 +29,29 @@ public class ValaNonJavaEmptyProjectWizard implements DirectoryProjectGenerator 
     }
 
     @Override
-    public void generateProject(@NotNull Project project, @NotNull VirtualFile virtualFile, @NotNull Object object, @NotNull Module module) {
-
+    public @NotNull @NlsContexts.Label String getDescription() {
+        return "Create a new Vala project";
     }
 
     @Override
-    public @NotNull ValidationResult validate(@NotNull String s) {
+    public void generateProject(@NotNull Project project, @NotNull VirtualFile virtualFile, @NotNull Object object, @NotNull Module module) {
+
+        WriteCommandAction.runWriteCommandAction(project, () -> {
+            try {
+                ValaProjectCreationUtil creationUtil = ValaProjectCreationUtil.getInstance();
+                creationUtil.setupNewProject(virtualFile, project, module);
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        });
+    }
+
+    @Override
+    public @NotNull ValidationResult validate(@NotNull String name) {
+        ProjectNameValidator nameValidator = ProjectNameValidator.getInstance();
+
+        if (!nameValidator.isValid(name)) return new ValidationResult("Invalid project name");
+
         return ValidationResult.OK;
     }
 }

--- a/src/main/java/com/tbusk/vala_plugin/project/ValaNonJavaEmptyProjectWizard.java
+++ b/src/main/java/com/tbusk/vala_plugin/project/ValaNonJavaEmptyProjectWizard.java
@@ -1,0 +1,35 @@
+package com.tbusk.vala_plugin.project;
+
+import com.intellij.facet.ui.ValidationResult;
+import com.intellij.openapi.module.Module;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.util.NlsContexts;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.platform.DirectoryProjectGenerator;
+import com.tbusk.vala_plugin.language.ValaIcons;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import javax.swing.*;
+
+public class ValaNonJavaEmptyProjectWizard implements DirectoryProjectGenerator {
+    @Override
+    public @NotNull @NlsContexts.Label String getName() {
+        return "Vala project";
+    }
+
+    @Override
+    public @Nullable Icon getLogo() {
+        return ValaIcons.FILE;
+    }
+
+    @Override
+    public void generateProject(@NotNull Project project, @NotNull VirtualFile virtualFile, @NotNull Object object, @NotNull Module module) {
+
+    }
+
+    @Override
+    public @NotNull ValidationResult validate(@NotNull String s) {
+        return ValidationResult.OK;
+    }
+}

--- a/src/main/java/com/tbusk/vala_plugin/project/ValaNonJavaMesonProjectWizard.java
+++ b/src/main/java/com/tbusk/vala_plugin/project/ValaNonJavaMesonProjectWizard.java
@@ -1,0 +1,72 @@
+package com.tbusk.vala_plugin.project;
+
+import com.intellij.facet.ui.ValidationResult;
+import com.intellij.ide.util.projectWizard.AbstractNewProjectStep;
+import com.intellij.ide.util.projectWizard.CustomStepProjectGenerator;
+import com.intellij.openapi.command.WriteCommandAction;
+import com.intellij.openapi.module.Module;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.util.NlsContexts;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.openapi.wm.impl.welcomeScreen.AbstractActionWithPanel;
+import com.intellij.platform.DirectoryProjectGenerator;
+import com.intellij.platform.ProjectGeneratorPeer;
+import com.tbusk.vala_plugin.language.ValaIcons;
+import org.jetbrains.annotations.Nls;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.swing.*;
+
+public class ValaNonJavaMesonProjectWizard implements DirectoryProjectGenerator<ValaProjectSettings>, CustomStepProjectGenerator<ValaProjectSettings> {
+
+    private static final Logger log = LoggerFactory.getLogger(ValaNonJavaMesonProjectWizard.class);
+
+    @Override
+    public @Nullable @Nls(capitalization = Nls.Capitalization.Sentence) String getDescription() {
+        return DirectoryProjectGenerator.super.getDescription();
+    }
+
+    @Override
+    public @NotNull @NlsContexts.Label String getName() {
+        return "Vala meson project";
+    }
+
+    @Override
+    public @Nullable Icon getLogo() {
+        return ValaIcons.FILE;
+    }
+
+    @Override
+    public @NotNull ProjectGeneratorPeer<ValaProjectSettings> createPeer() {
+        return new ValaProjectGeneratorPeer();
+    }
+
+    @Override
+    public void generateProject(@NotNull Project project, @NotNull VirtualFile virtualFile, @NotNull ValaProjectSettings projectSettings, @NotNull Module module) {
+        WriteCommandAction.runWriteCommandAction(project, () -> {
+            try {
+                ValaProjectCreationUtil creationUtil = ValaProjectCreationUtil.getInstance();
+                creationUtil.setupNewMesonProject(virtualFile, project, module);
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        });
+    }
+
+    @Override
+    public @NotNull ValidationResult validate(@NotNull String name) {
+        ProjectNameValidator nameValidator = ProjectNameValidator.getInstance();
+
+        if (!nameValidator.isValid(name)) return new ValidationResult("Invalid project name");
+
+        return ValidationResult.OK;
+    }
+
+    @Override
+    public AbstractActionWithPanel createStep(DirectoryProjectGenerator<ValaProjectSettings> directoryProjectGenerator, AbstractNewProjectStep.AbstractCallback<ValaProjectSettings> abstractCallback) {
+        return new ValaProjectSettingsStep(directoryProjectGenerator, abstractCallback);
+    }
+}

--- a/src/main/java/com/tbusk/vala_plugin/project/ValaProjectCreationUtil.java
+++ b/src/main/java/com/tbusk/vala_plugin/project/ValaProjectCreationUtil.java
@@ -1,0 +1,126 @@
+package com.tbusk.vala_plugin.project;
+
+import com.intellij.ide.fileTemplates.FileTemplate;
+import com.intellij.ide.fileTemplates.FileTemplateManager;
+import com.intellij.openapi.module.Module;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.roots.ContentEntry;
+import com.intellij.openapi.roots.ModifiableRootModel;
+import com.intellij.openapi.roots.ModuleRootManager;
+import com.intellij.openapi.vfs.VirtualFile;
+import org.jetbrains.annotations.NotNull;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Properties;
+
+public final class ValaProjectCreationUtil {
+
+    private static ValaProjectCreationUtil instance;
+
+    private ValaProjectCreationUtil() {
+    }
+
+    public static ValaProjectCreationUtil getInstance() {
+        if (instance == null) {
+            instance = new ValaProjectCreationUtil();
+        }
+
+        return instance;
+    }
+
+    public void setupNewMesonProject(@NotNull VirtualFile projectFile, @NotNull Project project, @NotNull Module module) throws IOException {
+        setupNewProject(projectFile, project, module);
+
+        FileTemplateManager templateManager = FileTemplateManager.getInstance(project);
+        VirtualFile mesonBuild = createMesonBuildFile(templateManager, projectFile, module);
+    }
+
+    public void setupNewProject(@NotNull VirtualFile projectFile, @NotNull Project project, @NotNull Module module) throws IOException {
+        FileTemplateManager templateManager = FileTemplateManager.getInstance(project);
+        VirtualFile sourcesDirectory = createSourceDirectory(projectFile, module);
+        VirtualFile mainDirectory = createMainDirectory(sourcesDirectory);
+        VirtualFile resourcesDirectory = createResourcesDirectory(mainDirectory);
+        VirtualFile valaSourceDirectory = createValaSourceDirectory(mainDirectory);
+        VirtualFile testDirectory = createTestDirectory(sourcesDirectory);
+        VirtualFile valaTestDirectory = createValaTestDirectory(testDirectory);
+        VirtualFile gitIgnore = createGitIgnoreFile(templateManager, projectFile);
+        VirtualFile editorConfig = createEditorConfigFile(templateManager, projectFile);
+        VirtualFile readme = createReadmeFile(templateManager, projectFile, module);
+    }
+
+    public VirtualFile createSourceDirectory(VirtualFile projectFile, Module module) throws IOException {
+        VirtualFile sourceDirectory = projectFile.createChildDirectory(this, "src");
+
+        ModifiableRootModel modifiableRootModel = ModuleRootManager.getInstance(module).getModifiableModel();
+        ContentEntry contentEntry = modifiableRootModel.addContentEntry(projectFile);
+        contentEntry.addSourceFolder(sourceDirectory, false);
+
+        modifiableRootModel.commit();
+
+        return sourceDirectory;
+    }
+
+    public VirtualFile createMainDirectory(VirtualFile sourcesDirectory) throws IOException {
+        return sourcesDirectory.createChildDirectory(this, "main");
+    }
+
+    public VirtualFile createResourcesDirectory(VirtualFile mainDirectory) throws IOException {
+        return mainDirectory.createChildDirectory(this, "resources");
+    }
+
+    public VirtualFile createValaSourceDirectory(VirtualFile mainDirectory) throws IOException {
+        return mainDirectory.createChildDirectory(this, "vala");
+    }
+
+    public VirtualFile createTestDirectory(VirtualFile sourceDirectory) throws IOException {
+        return sourceDirectory.createChildDirectory(this, "test");
+    }
+
+    public VirtualFile createValaTestDirectory(VirtualFile testDirectory) throws IOException {
+        return testDirectory.createChildDirectory(this, "vala");
+    }
+
+    public VirtualFile createMesonBuildFile(FileTemplateManager templateManager, VirtualFile projectFile, Module module) throws IOException {
+        FileTemplate mesonBuildTemplate = templateManager.getJ2eeTemplate("MesonBuild");
+
+        Properties mesonBuildProperties = new Properties();
+        mesonBuildProperties.setProperty("PROJECT_NAME", module.getName());
+
+        VirtualFile mesonBuildFile = projectFile.createChildData(this, "meson.build");
+        mesonBuildFile.setBinaryContent(mesonBuildTemplate.getText(mesonBuildProperties).getBytes(StandardCharsets.UTF_8));
+
+        return mesonBuildFile;
+    }
+
+    public VirtualFile createReadmeFile(FileTemplateManager templateManager, VirtualFile projectFile, Module module) throws IOException {
+        FileTemplate readmeTemplate = templateManager.getJ2eeTemplate("Readme");
+
+        Properties readmeProperties = new Properties();
+        readmeProperties.setProperty("PROJECT_NAME", module.getName());
+
+        VirtualFile readmeFile = projectFile.createChildData(this, "README.md");
+        readmeFile.setBinaryContent(readmeTemplate.getText(readmeProperties).getBytes(StandardCharsets.UTF_8));
+
+        return readmeFile;
+    }
+
+    public VirtualFile createEditorConfigFile(FileTemplateManager templateManager, VirtualFile projectFile) throws IOException {
+        FileTemplate editorConfigTemplate = templateManager.getJ2eeTemplate("EditorConfig");
+
+        VirtualFile editorConfigFile = projectFile.createChildData(this, ".editorconfig");
+        editorConfigFile.setBinaryContent(editorConfigTemplate.getText().getBytes(StandardCharsets.UTF_8));
+
+        return editorConfigFile;
+    }
+
+    public VirtualFile createGitIgnoreFile(FileTemplateManager templateManager, VirtualFile projectFile) throws IOException {
+        FileTemplate gitIgnoreTemplate = templateManager.getJ2eeTemplate("GitIgnore");
+
+        VirtualFile gitIgnoreFile = projectFile.createChildData(this, ".gitignore");
+        gitIgnoreFile.setBinaryContent(gitIgnoreTemplate.getText().getBytes(StandardCharsets.UTF_8));
+
+        return gitIgnoreFile;
+    }
+
+}

--- a/src/main/java/com/tbusk/vala_plugin/project/ValaProjectGeneratorPeer.java
+++ b/src/main/java/com/tbusk/vala_plugin/project/ValaProjectGeneratorPeer.java
@@ -1,0 +1,23 @@
+package com.tbusk.vala_plugin.project;
+
+import com.intellij.ide.util.projectWizard.SettingsStep;
+import com.intellij.platform.GeneratorPeerImpl;
+import org.jetbrains.annotations.NotNull;
+
+public class ValaProjectGeneratorPeer extends GeneratorPeerImpl<ValaProjectSettings> {
+    ValaProjectSettings projectSettings;
+
+    public ValaProjectGeneratorPeer() {
+        projectSettings = new ValaProjectSettings();
+    }
+
+    @Override
+    public @NotNull ValaProjectSettings getSettings() {
+        return projectSettings;
+    }
+
+    @Override
+    public void buildUI(@NotNull SettingsStep settingsStep) {
+        super.buildUI(settingsStep);
+    }
+}

--- a/src/main/java/com/tbusk/vala_plugin/project/ValaProjectSettings.java
+++ b/src/main/java/com/tbusk/vala_plugin/project/ValaProjectSettings.java
@@ -1,0 +1,4 @@
+package com.tbusk.vala_plugin.project;
+
+public class ValaProjectSettings {
+}

--- a/src/main/java/com/tbusk/vala_plugin/project/ValaProjectSettingsStep.java
+++ b/src/main/java/com/tbusk/vala_plugin/project/ValaProjectSettingsStep.java
@@ -1,0 +1,26 @@
+package com.tbusk.vala_plugin.project;
+
+import com.intellij.ide.util.projectWizard.AbstractNewProjectStep;
+import com.intellij.ide.util.projectWizard.ProjectSettingsStepBase;
+import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.intellij.platform.DirectoryProjectGenerator;
+import org.jetbrains.annotations.NotNull;
+
+import javax.swing.*;
+
+public class ValaProjectSettingsStep extends ProjectSettingsStepBase<ValaProjectSettings> {
+
+    public ValaProjectSettingsStep(DirectoryProjectGenerator projectGenerator, AbstractNewProjectStep.AbstractCallback callback) {
+        super(projectGenerator, callback);
+    }
+
+    @Override
+    protected JPanel createBasePanel() {
+        return super.createBasePanel();
+    }
+
+    @Override
+    public void actionPerformed(@NotNull AnActionEvent event) {
+        super.actionPerformed(event);
+    }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -87,6 +87,23 @@
                 implementation="com.tbusk.vala_plugin.project.ValaNonJavaEmptyProjectWizard"
                 id="VALA_EMPTY_NON_JAVA"
                 order="first"/>
+
+        <directoryProjectGenerator
+                implementation="com.tbusk.vala_plugin.project.ValaNonJavaMesonProjectWizard"
+                id="VALA_EMPTY_MESON_NON_JAVA"
+                order="after VALA_EMPTY_NON_JAVA"/>
+
+        <newProjectWizard.languageGenerator
+                implementation="com.tbusk.vala_plugin.project.ValaLanguageGeneratorNewProjectWizard"
+                id="VALA_EMPTY"
+                order="first"
+        />
+
+        <newProjectWizard.languageGenerator
+                implementation="com.tbusk.vala_plugin.project.ValaLanguageGeneratorNewMesonProjectWizard"
+                id="VALA_EMPTY_MESON"
+                order="after VALA_EMPTY"
+        />
     </extensions>
 
     <actions >

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -82,6 +82,11 @@
 
         <lang.commenter language="Vala"
                         implementationClass="com.tbusk.vala_plugin.comment_out.ValaCommenter"/>
+
+        <directoryProjectGenerator
+                implementation="com.tbusk.vala_plugin.project.ValaNonJavaEmptyProjectWizard"
+                id="VALA_EMPTY_NON_JAVA"
+                order="first"/>
     </extensions>
 
     <actions >

--- a/src/main/resources/fileTemplates/j2ee/EditorConfig.ft
+++ b/src/main/resources/fileTemplates/j2ee/EditorConfig.ft
@@ -1,0 +1,11 @@
+# top-most Editor Config File
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+
+[*.{vala,vapi}]
+indent_style = space
+indent_size = 4

--- a/src/main/resources/fileTemplates/j2ee/GitIgnore.ft
+++ b/src/main/resources/fileTemplates/j2ee/GitIgnore.ft
@@ -1,0 +1,11 @@
+# Meson
+build/
+
+# CLang
+.cache/
+
+# Jetbrains Editor
+.idea/
+
+# Misc
+*.env

--- a/src/main/resources/fileTemplates/j2ee/MesonBuild.ft
+++ b/src/main/resources/fileTemplates/j2ee/MesonBuild.ft
@@ -1,0 +1,24 @@
+## https://velocity.apache.org/engine/2.0/vtl-reference.html
+project(
+'${PROJECT_NAME}',
+'vala', 'c',
+version: '1.0.0',
+license: '',
+default_options : []
+)
+
+dependencies = [
+
+]
+
+source_files = files (
+[
+]
+)
+
+application = executable(
+'${PROJECT_NAME}',
+dependencies: dependencies,
+sources: source_files,
+install: true
+)

--- a/src/main/resources/fileTemplates/j2ee/Readme.ft
+++ b/src/main/resources/fileTemplates/j2ee/Readme.ft
@@ -1,0 +1,30 @@
+## https://velocity.apache.org/engine/2.0/vtl-reference.html
+# ${PROJECT_NAME}
+
+Provide a description of the project here.
+
+#[[### Installation
+]]#
+
+List the installation instructions here.
+
+1.
+
+#[[### Dependencies
+]]#
+
+List all required / optional dependencies here.
+
+1.
+
+#[[### Contributing
+]]#
+
+If contributions are wanted, either link to a contributing guide or describe what your vision is.
+
+#[[### License
+Pick a license most suited for your needs. If you do not share it, then no permission will be granted to anyone who
+views or uses the project to do anything with it.
+
+Read more at https://choosealicense.com/
+]]#


### PR DESCRIPTION
Partially satisfied #44 where meson files come with a meson project when selecting new project wizard with meson.

## Description
Adding project wizards to use in all IDEs where the user gets a choice of a meson-based project or a standard project.

A few standard files and directories are included like `.editorconfig`, `.gitignore`, `README.md`, (if meson selected, a configured `meson.build`), and a JetBrains source structure of src -> main -> lang, src -> main -> resources, src -> test -> lang