### PR TITLE
patch: bump plugin verifier version as fix was implemented

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -55,7 +55,7 @@ dependencies {
 
         testFramework(TestFrameworkType.Platform)
 
-        pluginVerifier(version="1.384")
+        pluginVerifier(version = "1.388")
     }
 }
 


### PR DESCRIPTION
Locally, the plugin verifier works now with the latest version, version 1.388.  The previous three versions had dependency resolution issues.