### PR TITLE
patch: update parser for attributes to handle more complex usages

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -38,7 +38,8 @@ body:
       label: Version
       description: What version of the plugin are you using?
       options:
-        - Latest
+        - Latest (if not added)
+        - 1.2.1-ALPHA
         - 1.2.0-ALPHA
         - 1.1.3-ALPHA
         - 1.1.2-ALPHA

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@
 
 ### What's Changed
 
+- Added keyword highlighting for delegate
+- Patched indentation for errordomain and attribute pairing.
+- Updated parser to permit multiple identifiers / arguments rather than
+  a single one per attribute
+
+## [1.2.0-ALPHA]
+
+### What's Changed
 - Added new Vala project wizard to Java-based IDEs
 - Added new Vala project wizard with Meson to Java-based IDEs
 - Added new Vala project wizard to non-Java-based IDEs

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ pluginGroup = com.tbusk.vala_plugin
 pluginName = Vala Language
 pluginRepositoryUrl = https://github.com/Tbusk/vala-jetbrains-plugin
 # SemVer format -> https://semver.org
-pluginVersion=1.2.0-ALPHA
+pluginVersion=1.2.1-ALPHA
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 pluginSinceBuild = 251

--- a/src/main/gen/com/tbusk/vala_plugin/ValaParser.java
+++ b/src/main/gen/com/tbusk/vala_plugin/ValaParser.java
@@ -421,7 +421,7 @@ public class ValaParser implements PsiParser, LightPsiParser {
   }
 
   /* ********************************************************** */
-  // LBRACKET IDENTIFIER [ attribute_arguments ] RBRACKET
+  // LBRACKET IDENTIFIER [ attribute_arguments ] [ (COMMA IDENTIFIER [ attribute_arguments ])* ] RBRACKET
   public static boolean attribute(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "attribute")) return false;
     if (!nextTokenIs(b, LBRACKET)) return false;
@@ -429,6 +429,7 @@ public class ValaParser implements PsiParser, LightPsiParser {
     Marker m = enter_section_(b);
     r = consumeTokens(b, 0, LBRACKET, IDENTIFIER);
     r = r && attribute_2(b, l + 1);
+    r = r && attribute_3(b, l + 1);
     r = r && consumeToken(b, RBRACKET);
     exit_section_(b, m, ATTRIBUTE, r);
     return r;
@@ -437,6 +438,42 @@ public class ValaParser implements PsiParser, LightPsiParser {
   // [ attribute_arguments ]
   private static boolean attribute_2(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "attribute_2")) return false;
+    attribute_arguments(b, l + 1);
+    return true;
+  }
+
+  // [ (COMMA IDENTIFIER [ attribute_arguments ])* ]
+  private static boolean attribute_3(PsiBuilder b, int l) {
+    if (!recursion_guard_(b, l, "attribute_3")) return false;
+    attribute_3_0(b, l + 1);
+    return true;
+  }
+
+  // (COMMA IDENTIFIER [ attribute_arguments ])*
+  private static boolean attribute_3_0(PsiBuilder b, int l) {
+    if (!recursion_guard_(b, l, "attribute_3_0")) return false;
+    while (true) {
+      int c = current_position_(b);
+      if (!attribute_3_0_0(b, l + 1)) break;
+      if (!empty_element_parsed_guard_(b, "attribute_3_0", c)) break;
+    }
+    return true;
+  }
+
+  // COMMA IDENTIFIER [ attribute_arguments ]
+  private static boolean attribute_3_0_0(PsiBuilder b, int l) {
+    if (!recursion_guard_(b, l, "attribute_3_0_0")) return false;
+    boolean r;
+    Marker m = enter_section_(b);
+    r = consumeTokens(b, 0, COMMA, IDENTIFIER);
+    r = r && attribute_3_0_0_2(b, l + 1);
+    exit_section_(b, m, null, r);
+    return r;
+  }
+
+  // [ attribute_arguments ]
+  private static boolean attribute_3_0_0_2(PsiBuilder b, int l) {
+    if (!recursion_guard_(b, l, "attribute_3_0_0_2")) return false;
     attribute_arguments(b, l + 1);
     return true;
   }

--- a/src/main/gen/com/tbusk/vala_plugin/psi/ValaAttribute.java
+++ b/src/main/gen/com/tbusk/vala_plugin/psi/ValaAttribute.java
@@ -7,10 +7,7 @@ import com.intellij.psi.PsiElement;
 
 public interface ValaAttribute extends PsiElement {
 
-  @Nullable
-  ValaAttributeArguments getAttributeArguments();
-
   @NotNull
-  PsiElement getIdentifier();
+  List<ValaAttributeArguments> getAttributeArgumentsList();
 
 }

--- a/src/main/gen/com/tbusk/vala_plugin/psi/impl/ValaAttributeImpl.java
+++ b/src/main/gen/com/tbusk/vala_plugin/psi/impl/ValaAttributeImpl.java
@@ -28,15 +28,9 @@ public class ValaAttributeImpl extends ASTWrapperPsiElement implements ValaAttri
   }
 
   @Override
-  @Nullable
-  public ValaAttributeArguments getAttributeArguments() {
-    return findChildByClass(ValaAttributeArguments.class);
-  }
-
-  @Override
   @NotNull
-  public PsiElement getIdentifier() {
-    return findNotNullChildByType(IDENTIFIER);
+  public List<ValaAttributeArguments> getAttributeArgumentsList() {
+    return PsiTreeUtil.getChildrenOfTypeAsList(this, ValaAttributeArguments.class);
   }
 
 }

--- a/src/main/java/com/tbusk/vala_plugin/ValaTokenSets.java
+++ b/src/main/java/com/tbusk/vala_plugin/ValaTokenSets.java
@@ -125,6 +125,7 @@ public interface ValaTokenSets {
             ValaTypes.PREPROCESSOR_ELIF,
             ValaTypes.PREPROCESSOR_ELSE,
             ValaTypes.PREPROCESSOR_ENDIF,
-            ValaTypes.INLINE
+            ValaTypes.INLINE,
+            ValaTypes.DELEGATE
     );
 }

--- a/src/main/java/com/tbusk/vala_plugin/code_style/ValaBlock.java
+++ b/src/main/java/com/tbusk/vala_plugin/code_style/ValaBlock.java
@@ -96,6 +96,13 @@ public class ValaBlock extends AbstractBlock {
         IElementType parentType = myNode.getElementType();
         IElementType childType = child.getElementType();
 
+        if ((parentType == ValaTypes.CLASS_MEMBER ||
+                parentType == ValaTypes.NAMESPACE_MEMBER ||
+                parentType == ValaTypes.INTERFACE_MEMBER ||
+                parentType == ValaTypes.STRUCT_MEMBER) && (myNode.findChildByType(ValaTypes.ATTRIBUTES) != null || myNode.findChildByType(ValaTypes.ATTRIBUTE) != null)) {
+            return Indent.getNoneIndent();
+        }
+
         if (parentType == ValaTypes.PREPROCESSOR_DIRECTIVE || childType == ValaTypes.PREPROCESSOR_DIRECTIVE) {
             return Indent.getAbsoluteNoneIndent();
         }
@@ -108,7 +115,7 @@ public class ValaBlock extends AbstractBlock {
             return Indent.getNormalIndent();
         }
 
-        if (parentType == ValaTypes.ERRORDOMAIN_DECLARATION && (childType != ValaTypes.SEMICOLON && childType != ValaTypes.RBRACE)) {
+        if (parentType == ValaTypes.ERRORDOMAIN_DECLARATION && (childType == ValaTypes.ERRORCODES || childType == ValaTypes.METHOD_DECLARATION)) {
             return Indent.getNormalIndent();
         }
 
@@ -126,10 +133,6 @@ public class ValaBlock extends AbstractBlock {
 
         if (parentType == ValaTypes.STRUCT_DECLARATION && childType == ValaTypes.STRUCT_MEMBER) {
             return Indent.getNormalIndent();
-        }
-
-        if ((parentType == ValaTypes.CLASS_MEMBER || parentType == ValaTypes.NAMESPACE_MEMBER || parentType == ValaTypes.INTERFACE_MEMBER) && myNode.findChildByType(ValaTypes.ATTRIBUTES) != null) {
-            return Indent.getNoneIndent();
         }
 
         if (parentType == ValaTypes.ENUM_DECLARATION &&

--- a/src/main/java/com/tbusk/vala_plugin/syntax/Vala.bnf
+++ b/src/main/java/com/tbusk/vala_plugin/syntax/Vala.bnf
@@ -114,7 +114,7 @@ namespace_member ::= [ attributes ]
 
 attributes ::= attribute*
 
-attribute ::= LBRACKET IDENTIFIER [ attribute_arguments ] RBRACKET
+attribute ::= LBRACKET IDENTIFIER [ attribute_arguments ] [ (COMMA IDENTIFIER [ attribute_arguments ])* ] RBRACKET
 
 attribute_arguments ::= LPAREN attribute_argument [ (COMMA attribute_argument)* ] RPAREN
 

--- a/src/test/vala/samples/attributes/before_namespace_attribute.vala
+++ b/src/test/vala/samples/attributes/before_namespace_attribute.vala
@@ -1,0 +1,40 @@
+[Flags, CCode (cname = "int", cprefix = "SDL_INIT_", has_type_id = false)]
+public enum InitFlags {
+    AUDIO,
+    VIDEO,
+    JOYSTICK,
+    HAPTIC,
+    GAMEPAD,
+    EVENTS,
+    SENSOR,
+    CAMERA
+}
+
+[Diagnostics, SimpleType, CCode (cname = "cname_property", has_type_id = false)]
+public class BeforeNamespaceAttributeClass {
+
+}
+
+[CCode (cname = "cname_property", has_type_id = false), Diagnostics, SimpleType]
+public struct PropertiesID : uint32 {}
+
+[Diagnostics, CCode (cname = "cname_property", has_type_id = false), SimpleType]
+public virtual delegate uint TestDelegate ();
+
+[Diagnostics, PrintfFormat]
+public errordomain decl {
+    ERROR;
+}
+
+[Diagnostics, PrintfFormat]
+const uint CONSTANT = 1;
+
+[SimpleType, CCode (cname = "SDL_PropertiesID", has_type_id = false)]
+public uint get_enums () {
+    return 1u;
+}
+
+[SimpleType, CCode (cname = "SDL_PropertiesID", has_type_id = false)]
+public interface TestInterface {
+
+}


### PR DESCRIPTION
## Description
The original implementation of attributes in the bnf grammar file don't take into account the number of inner arguments that can be used. More than one can be used at a time.

### Changes
- Added keyword highlighting for delegate
- Patched indentation for errordomain and attribute pairing.
- Updated parser to permit multiple identifiers / arguments rather than a single one per attribute
- Added sample code for outside-namespace attribute usage