### PR TITLE
chore: tweak failing test output, update bug report to have latest plugin versions

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -25,9 +25,7 @@ body:
       label: Steps to Reproduce
       description: Please list the steps that are needed to reproduce the issue if possible.
       value: |
-        1. 
-        2. 
-        3. 
+        1.
         ...
       render: bash
     validations:
@@ -39,6 +37,9 @@ body:
       description: What version of the plugin are you using?
       options:
         - Latest (if not added)
+        - 1.2.4-ALPHA
+        - 1.2.3-ALPHA
+        - 1.2.2-ALPHA
         - 1.2.1-ALPHA
         - 1.2.0-ALPHA
         - 1.1.3-ALPHA

--- a/src/test/java/parser/public_repos/ValaCodeParserTest.java
+++ b/src/test/java/parser/public_repos/ValaCodeParserTest.java
@@ -21,10 +21,11 @@ public class ValaCodeParserTest extends BasePlatformTestCase {
                         "enum_only.vala",
                         "struct_only.vala",
                         "glib-2.0.vapi",
-                        "regex.vala"
+                        "regex.vala",
+                        "bug761267-2.vala"
                 )
         );
 
-        IntegrationTestUtils.testRepoSourceFilesForParsingErrors(this.myFixture, repositoryZipUrl, "vala", 1, errorsToIgnore);
+        IntegrationTestUtils.testRepoSourceFilesForParsingErrors(this.myFixture, repositoryZipUrl, "vala", 0, errorsToIgnore);
     }
 }


### PR DESCRIPTION
## Description

- Updating test that fails to skip failing test case rather than ignore it
- Update bug report plugin version dropdown to contain latest versions