### PR TITLE
patch: add dependabot dep update title to pr title allow list

### DIFF
--- a/.github/pr-title-checker-config.json
+++ b/.github/pr-title-checker-config.json
@@ -10,7 +10,8 @@
       "change: ",
       "docs: ",
       "test: ",
-      "chore: "
+      "chore: ",
+      "chore(deps):"
     ]
   },
   "MESSAGES": {


### PR DESCRIPTION
### Summary

<!-- Provide a general summary of what this PR achieves -->
PRs from dependebot are failing due to a title naming difference. This adds the default to it.

### Type of Change

- [ ] Feature: A new feature has been implemented.
- [x] Patch / Bug Fix: A fix for an issue found.
- [ ] Change: A change has been made.

### PR Details

<!-- Describe in more detail what this PR achieves and why, and anything that is important to know about it -->
This PR adds `chore(deps):` to the allowable titles.

### Additional Information

<!-- Include anything additional, like helpful links, supporting docs, screenshots, etc. -->
N/A
