### PR TITLE
change: ignore dependabot in ATP/PTC workflows and fix title

### DIFF
--- a/.github/workflows/add_to_project.yml
+++ b/.github/workflows/add_to_project.yml
@@ -1,4 +1,4 @@
-name: add_to_project.yml
+name: Add to Project
 on:
   issues:
     types:
@@ -9,6 +9,7 @@ on:
 jobs:
   add-to-project:
     name: Add issue to project
+    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/add-to-project@v1.0.2

--- a/.github/workflows/pr-title-checker.yml
+++ b/.github/workflows/pr-title-checker.yml
@@ -10,6 +10,7 @@ on:
 
 jobs:
   check:
+    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
       - uses: thehanimo/pr-title-checker@v1.4.3


### PR DESCRIPTION
<!-- Thank you for your contribution! Please fill out this template to help us review your PR -->

<!-- Add an issue number below. If one hasn't been created, create one -->
Closes #118, #119

### Summary

<!-- Provide a general summary of what this PR achieves -->
This PR gives a better title to add to project workflow and skips `add to project` and `pr title checker` workflows for dependabot

### Type of Change

- [ ] Feature: A new feature has been implemented.
- [ ] Patch / Bug Fix: A fix for an issue found.
- [x] Change: A change has been made.

### PR Details

<!-- Describe in more detail what this PR achieves and why, and anything that is important to know about it -->

Summary is sufficient for this small change.

### Additional Information

<!-- Include anything additional, like helpful links, supporting docs, screenshots, etc. -->
N/A
