### PR TITLE
change: remove unused dep grammar kit

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,6 @@ repositories {
 dependencies {
     testImplementation libs.junit
     testImplementation libs.opentest4j
-    compileOnly 'org.jetbrains:grammar-kit:2023.3'
 
     intellijPlatform {
         create(providers.gradleProperty('platformType'), providers.gradleProperty('platformVersion'))


### PR DESCRIPTION
<!-- Thank you for your contribution! Please fill out this template to help us review your PR -->

<!-- Add an issue number below. If one hasn't been created, create one -->
Closes #176

### Summary

<!-- Provide a general summary of what this PR achieves -->
This PR removes the dependency `grammar-kit` from `build.gradle`.

### Type of Change

- [ ] Feature: A new feature has been implemented.
- [ ] Patch / Bug Fix: A fix for an issue found.
- [X] Change: A change has been made.

### PR Details

<!-- Describe in more detail what this PR achieves and why, and anything that is important to know about it -->
This PR removes the dependency `grammar-kit` because it is unused in the sense that gradle nor the vala plugin doesn't actually need it. The grammar kit plugin is used for generating the parser and doing live preview parser checks, but not the actual dependency. 

### Additional Information

<!-- Include anything additional, like helpful links, supporting docs, screenshots, etc. -->
N/A
